### PR TITLE
Add until command

### DIFF
--- a/lldb/core.el
+++ b/lldb/core.el
@@ -159,7 +159,7 @@ Note that path elements have been expanded via `expand-file-name'.
 (defvar realgud:lldb-command-name)
 
 (defun realgud:lldb-executable (file-name)
-"Return a priority for wehther file-name is likely we can run lldb on"
+"Return a priority for whether file-name is likely we can run lldb on"
   (let ((output (shell-command-to-string (format "file %s" file-name))))
     (cond
      ((string-match "ASCII" output) 2)

--- a/lldb/init.el
+++ b/lldb/init.el
@@ -146,6 +146,7 @@ realgud-loc-pat struct")
 (setf (gethash "quit"     realgud:lldb-command-hash) "quit")
 (setf (gethash "run"      realgud:lldb-command-hash) "run")
 (setf (gethash "step"     realgud:lldb-command-hash) "thread step-in --count %p")
+(setf (gethash "until"    realgud:lldb-command-hash) "thread until %l")
 (setf (gethash "lldb" realgud-command-hash) realgud:lldb-command-hash)
 
 (setf (gethash "lldb" realgud-pat-hash) realgud:lldb-pat-hash)


### PR DESCRIPTION
This PR adds support for the "until" command in LLDB: Run the program until a given line in source code.