### PR TITLE
Customize lldb frame format to tell us full source file paths

### DIFF
--- a/lldb/lldb.el
+++ b/lldb/lldb.el
@@ -81,6 +81,14 @@ fringe and marginal icons.
 	(with-current-buffer cmd-buf
 	  (set (make-local-variable 'realgud--lldb-file-remap)
 	       (make-hash-table :test 'equal))
+	  ;; The following directs lldb to emit full paths
+	  ;; when stopping at a breakpoint,
+	  ;; which lets us find the file.
+	  ;; Unfortunately lldb only emits base file names
+	  ;; when setting breakpoints,
+	  ;; so we still show an unhelpful prompt at that time.
+	  (realgud-command "settings set frame-format frame #${frame.index}: ${frame.pc}{ ${module.file.basename}{\`${function.name}}}{ at ${line.file.fullpath}:${line.number}}\n"
+			   nil nil nil)
 	  (realgud:remove-ansi-schmutz)
 	  )
       )


### PR DESCRIPTION
This improves the situation described in #10 a bit, but does not completely eliminate the issue.