### PR TITLE
Fix frame-format carriage return

### DIFF
--- a/lldb/lldb.el
+++ b/lldb/lldb.el
@@ -87,7 +87,7 @@ fringe and marginal icons.
 	  ;; Unfortunately lldb only emits base file names
 	  ;; when setting breakpoints,
 	  ;; so we still show an unhelpful prompt at that time.
-	  (realgud-command "settings set frame-format frame #${frame.index}: ${frame.pc}{ ${module.file.basename}{\`${function.name}}}{ at ${line.file.fullpath}:${line.number}}\n"
+	  (realgud-command "settings set frame-format frame #${frame.index}: ${frame.pc}{ ${module.file.basename}{\`${function.name}}}{ at ${line.file.fullpath}:${line.number}}\\n"
 			   nil nil nil)
 	  (realgud:remove-ansi-schmutz)
 	  )


### PR DESCRIPTION
Fixes frame-format to add a carriage return at the end of each frame

Before:
```
(lldb) settings set frame-format frame #${frame.index}: ${frame.pc}{ ${module.file.basename}{`${function.name}}}{ at ${line.file.fullpath}:${line.number}}
[...]
(lldb) bt
bt
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  * frame #0: 0x00007ff807613202 libsystem_kernel.dylib`__pthread_kill    frame #1: 0x00007ff80764aee6 libsystem_pthread.dylib`pthread_kill    frame #2: 0x00007ff807571b45 libsystem_c.dylib`abort    frame #3: 0x00007ff807605282 libc++abi.dylib`abort_message    frame #4: 0x00007ff8075f73e1 libc++abi.dylib`demangling_terminate_handler()    frame #5: 0x00007ff8072cb7d6 libobjc.A.dylib`_objc_terminate()    frame #6: 0x00007ff8076046db libc++abi.dylib`std::__terminate(void (*)())    frame #7: 0x00007ff807606fa7 libc++abi.dylib`__cxxabiv1::failed_throw(__cxxabiv1::__cxa_exception*)    frame #8: 0x00007ff807606f6e libc++abi.dylib`__cxa_throw 
```

After:
```
(lldb) settings set frame-format frame #${frame.index}: ${frame.pc}{ ${module.file.basename}{`${function.name}}}{ at ${line.file.fullpath}:${line.number}}\n
[...]
(lldb) bt
bt
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  * frame #0: 0x00007ff807613202 libsystem_kernel.dylib`__pthread_kill
    frame #1: 0x00007ff80764aee6 libsystem_pthread.dylib`pthread_kill
    frame #2: 0x00007ff807571b45 libsystem_c.dylib`abort
    frame #3: 0x00007ff807605282 libc++abi.dylib`abort_message
    frame #4: 0x00007ff8075f73e1 libc++abi.dylib`demangling_terminate_handler()
    frame #5: 0x00007ff8072cb7d6 libobjc.A.dylib`_objc_terminate()
    frame #6: 0x00007ff8076046db libc++abi.dylib`std::__terminate(void (*)())
    frame #7: 0x00007ff807606fa7 libc++abi.dylib`__cxxabiv1::failed_throw(__cxxabiv1::__cxa_exception*)
    frame #8: 0x00007ff807606f6e libc++abi.dylib`__cxa_throw
```